### PR TITLE
google: allow to specify suggested domain

### DIFF
--- a/internal/provider/google.go
+++ b/internal/provider/google.go
@@ -14,6 +14,7 @@ type Google struct {
 	ClientSecret string `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
 	Scope        string
 	Prompt       string `long:"prompt" env:"PROMPT" default:"select_account" description:"Space separated list of OpenID prompt options"`
+	EmailDomain  string `long:"email-domain" env:"EMAIL_DOMAIN" description:"Email domain the user is suggested to login with"`
 
 	LoginURL *url.URL
 	TokenURL *url.URL
@@ -60,6 +61,9 @@ func (g *Google) GetLoginURL(redirectURI, state string) string {
 	q.Set("scope", g.Scope)
 	if g.Prompt != "" {
 		q.Set("prompt", g.Prompt)
+	}
+	if g.EmailDomain != "" {
+		q.Set("hd", g.EmailDomain)
 	}
 	q.Set("redirect_uri", redirectURI)
 	q.Set("state", state)


### PR DESCRIPTION
This pulls in https://github.com/thomseddon/traefik-forward-auth/pull/293, whose description reads:

> As per the Google OIDC docs, the `hd` parameter may be used to suggest the domain the user may login with:
> https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param
> 
> In effect, the Google account chooser only displays accounts with that very domain, which simplifies the process for users with very long account lists.

This will let us restrict our auth wall to only show accounts from the Mux domain, simplifying the auth wall flow if anybody happens to be logged in to other Google accounts.